### PR TITLE
Improve bot's main entry point

### DIFF
--- a/__main__.py
+++ b/__main__.py
@@ -161,4 +161,13 @@ bot.add_plugin(Core(bot))
 ### ENTRY ###
 #############
 
-asyncio.run(bot.start())
+async def main():
+    try:
+        await bot.start()
+    finally:
+        await bot.close()
+        # give Windows's asyncio event loop some time to prevent RuntimeError...
+        await asyncio.sleep(1)
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
Ensures the client is closed on bot shutdown and also adds a 1 second sleep mainly for Windows people to prevent an exception on shutdown due to a bug in Python's asyncio.
See:
https://github.com/jack1142/Mutiny/blob/main/examples/basic_client.py