### PR TITLE
Stop importing from internal namespaces when you can from public

### DIFF
--- a/__main__.py
+++ b/__main__.py
@@ -13,7 +13,6 @@ from rich.panel import Panel
 from rich import print
 
 from mutiny import Client, events
-from mutiny._internal.rest import RESTClient
 
 from ext.bot import Bot
 from ext import errors

--- a/ext/bot.py
+++ b/ext/bot.py
@@ -9,13 +9,12 @@ import pathlib
 from ulid import monotonic as ulid
 
 import mutiny
-from mutiny._internal.client import Client
 from . import commands
 from . import objects
 from . import errors
 
 
-class Bot(Client):
+class Bot(mutiny.Client):
     _commands = {}
     _aliased_commands = {}
 

--- a/ext/objects.py
+++ b/ext/objects.py
@@ -3,10 +3,9 @@ import functools
 import os
 
 import mutiny
-from mutiny._internal.models import attachment, channel, message, permissions, server, user
-from mutiny._internal.models.bases import StatefulResource, StatefulModel
+from mutiny import models
 
-_SUPPORTED_TYPES = (user.User, channel.TextChannel, message.Message)
+_SUPPORTED_TYPES = (models.User, models.TextChannel, models.Message)
 
 
 class MutinyPatch:


### PR DESCRIPTION
I re-export these into the public namespace so that you use them from the public namespace :P
Also fixes the compatibility with the breaking changes that will be done in the next release.